### PR TITLE
Correction to recent #Const parsing change to the scanner

### DIFF
--- a/vbnc/vbnc/source/General/Scanner.vb
+++ b/vbnc/vbnc/source/General/Scanner.vb
@@ -207,13 +207,10 @@ Public Class Scanner
             Return
         End If
 
-        'All errors are reported against the line that the #Const directive appears on
-        Dim constDirectiveLoc As New Span(m_CodeFileIndex, m_CurrentLine)
-
         Me.NextUnconditionally()
 
         If m_Current.IsIdentifier = False Then
-            Compiler.Report.ShowMessage(Messages.VBNC30203, constDirectiveLoc)
+            Compiler.Report.ShowMessage(Messages.VBNC30203, m_Current.Location)
             Me.EatLine(False)
             Return
         End If
@@ -221,7 +218,7 @@ Public Class Scanner
         Me.NextUnconditionally()
 
         If m_Current <> KS.Equals Then
-            Compiler.Report.ShowMessage(Messages.VBNC30249, constDirectiveLoc)
+            Compiler.Report.ShowMessage(Messages.VBNC30249, m_Current.Location)
             Return
         End If
         Me.NextUnconditionally()
@@ -1348,8 +1345,12 @@ Public Class Scanner
                 Case COMMENTCHAR1, COMMENTCHAR2, COMMENTCHAR3 'VB Comment
                     EatComment()
                 Case nlD, nlA, nl2028, nl2029 'New line
-                    EatNewLine()
+
+                    'Keep the current line of the end of line token to the current line so we get better
+                    'location info for errors and warnings
                     Result = Token.CreateEndOfLineToken(GetCurrentLocation)
+                    EatNewLine()
+
                 Case nl0 'End of file
                     Result = Token.CreateEndOfFileToken(GetCurrentLocation)
                 Case ":"c ':

--- a/vbnc/vbnc/source/Tokens/Token.vb
+++ b/vbnc/vbnc/source/Tokens/Token.vb
@@ -20,6 +20,7 @@
 Public Structure Token
     Public m_TokenType As TokenType
     Public m_TokenObject As Object
+    Public m_Location As Span
 
     Shared Function IsSomething(ByVal Token As Token) As Boolean
         'Return Token IsNot Nothing AndAlso Token.IsSomething
@@ -164,6 +165,7 @@ Public Structure Token
     End Function
 
     Sub New(ByVal Span As Span)
+        m_Location = Span
     End Sub
 
     Function IdentiferOrKeywordIdentifier() As String
@@ -474,6 +476,13 @@ Public Structure Token
             Return "not a symbol"
         End Get
     End Property
+
+    ReadOnly Property Location As Span
+        Get
+            Return m_Location
+        End Get
+    End Property
+
 End Structure
 
 


### PR DESCRIPTION
My recent changes to improve error reporting for invalid #Const directives had some invalid patch hunks applied from an earlier variant of the patch I was toying with that was incorrectly applied to my local tree instead of the correct patch when I pushed the changes back. 

Unfortunately I did not spot this until after the pull request containing the change had been merged in so the linked commit corrects those invalid hunks and applies the correct changes in their place.

The main change here is to tweak the location information for end of line tokens so that their line number matches the physical line which has just ended instead of being assigned the following line number. The changes to the Token class are to store the locations which are already being passed to its constructor, but were being silently discarded and to provide an accessor for that location so it can be used as the location for errors.

The patch has been successfully regression tested with no new failures.
