### PR TITLE
ensure git command calls always have exit status 0

### DIFF
--- a/vbnc/vbnc/setversion.sh
+++ b/vbnc/vbnc/setversion.sh
@@ -3,8 +3,8 @@
 VERSION_VB=$1
 VERSION_TMP=version.tmp
 
-GIT_BRANCH=`git branch | grep '^\*' | cut -d ' ' -f 2`
-GIT_REVISION=`git log --no-color --first-parent -n1 --pretty=format:%h`
+GIT_BRANCH=`git branch | grep '^\*' | cut -d ' ' -f 2; true`
+GIT_REVISION=`git log --no-color --first-parent -n1 --pretty=format:%h; true`
 
 cat ../LicenseFileHeader.txt > $VERSION_TMP
 echo "" >> $VERSION_TMP


### PR DESCRIPTION
setversion.sh tries to embed either a git revision, or "tarball", in Version.vb

If git is not installed, or you are building from a non-git tree (e.g. a tarball) then the git commands fail, causing the script to bail out - thus the "tarball" version can never be set.

This patch calls "true" immediately after "git", so the exit status is always 0, and the script carries on normally
