### PR TITLE
Fix Microsoft.VisualBasic.dll AssemblyVersion number

### DIFF
--- a/vbruntime/Microsoft.VisualBasic/AssemblyInfo.vb
+++ b/vbruntime/Microsoft.VisualBasic/AssemblyInfo.vb
@@ -66,16 +66,16 @@ Imports System.Security
 <Assembly: AssemblyDefaultAlias("Microsoft.VisualBasic.dll")> 
 #Else
 #If NET_VER >= 4.5 Then
-<Assembly: AssemblyVersion("11.0.0.0")> 
+<Assembly: AssemblyVersion("10.0.0.0")> 
 <Assembly: ComVisible(True)> 
 '<Assembly: Guid("aa353322-85a4-4601-a6b7-e3b724e9350c")> 
 <Assembly: CLSCompliant(True)> 
 <Assembly: Debuggable(DebuggableAttribute.DebuggingModes.Default Or DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)> 
 <Assembly: CompilationRelaxations(CompilationRelaxations.NoStringInterning)> 
 <Assembly: RuntimeCompatibility(WrapNonExceptionThrows:=True)> 
-<Assembly: SatelliteContractVersion("11.0.0.0")> 
-<Assembly: AssemblyInformationalVersion("11.0.30319.17020")> 
-<Assembly: AssemblyFileVersion("11.0.30319.17020")> 
+<Assembly: SatelliteContractVersion("10.0.0.0")> 
+<Assembly: AssemblyInformationalVersion("10.0.30319.17020")> 
+<Assembly: AssemblyFileVersion("10.0.30319.17020")> 
 <Assembly: AssemblyDefaultAlias("Microsoft.VisualBasic.dll")> 
 #ElseIf NET_VER >= 4.0 Then
 <Assembly: AssemblyVersion("10.0.0.0")> 


### PR DESCRIPTION
It was set to 11.0 when the net_4_5 profile was introduced in 9bae7fd107cdfff4e257282f4db5f92123916cd1.
Turns out this is actually wrong, since MS used 10.0 even for the net_4_5 version of the assembly.

This was never noticed because Mono internally remapped the assembly to the v10.0 version (see the remap logic in assembly.c), but now with Mono 4.0 removing earlier profiles it started failing. Fixing this by setting the AssemblyVersion to the correct value.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=29688