### PR TITLE
Swap Versioned.CallByName and Interaction.CallByName bodies

### DIFF
--- a/vbruntime/Microsoft.VisualBasic/Microsoft.VisualBasic.CompilerServices/Versioned.vb
+++ b/vbruntime/Microsoft.VisualBasic/Microsoft.VisualBasic.CompilerServices/Versioned.vb
@@ -39,8 +39,19 @@ Namespace Microsoft.VisualBasic.CompilerServices
         Private Sub New()
             'Nobody should see constructor
         End Sub
+        <MonoLimitation("CallType.Let options is not supported.")> _
         Public Shared Function CallByName(ByVal Instance As Object, ByVal MethodName As String, ByVal UseCallType As CallType, ByVal ParamArray Arguments As Object()) As Object
-            Return Interaction.CallByName(Instance, MethodName, UseCallType, Arguments)
+            Select Case UseCallType
+                Case CallType.Get
+                    Return LateBinding.LateGet(Instance, Instance.GetType(), MethodName, Arguments, Nothing, Nothing)
+                Case CallType.Let
+                    Throw New NotImplementedException("Microsoft.VisualBasic.Versioned.CallByName Case CallType.Let")
+                Case CallType.Method
+                    LateBinding.LateCall(Instance, Instance.GetType(), MethodName, Arguments, Nothing, Nothing)
+                Case CallType.Set
+                    LateBinding.LateSet(Instance, Instance.GetType(), MethodName, Arguments, Nothing)
+            End Select
+            Return Nothing
         End Function
         Public Shared Function IsNumeric(ByVal Expression As Object) As Boolean
 

--- a/vbruntime/Microsoft.VisualBasic/Microsoft.VisualBasic/Interaction.vb
+++ b/vbruntime/Microsoft.VisualBasic/Microsoft.VisualBasic/Interaction.vb
@@ -58,19 +58,8 @@ Namespace Microsoft.VisualBasic
         End Sub
 
 #End If
-        <MonoLimitation("CallType.Let options is not supported.")> _
         Public Shared Function CallByName(ByVal ObjectRef As Object, ByVal ProcName As String, ByVal UseCallType As Microsoft.VisualBasic.CallType, ByVal ParamArray Args() As Object) As Object
-            Select Case UseCallType
-                Case CallType.Get
-                    Return LateBinding.LateGet(ObjectRef, ObjectRef.GetType(), ProcName, Args, Nothing, Nothing)
-                Case CallType.Let
-                    Throw New NotImplementedException("Microsoft.VisualBasic.Interaction.CallByName Case CallType.Let")
-                Case CallType.Method
-                    LateBinding.LateCall(ObjectRef, ObjectRef.GetType(), ProcName, Args, Nothing, Nothing)
-                Case CallType.Set
-                    LateBinding.LateSet(ObjectRef, ObjectRef.GetType(), ProcName, Args, Nothing)
-            End Select
-            Return Nothing
+            Return Versioned.CallByName(ObjectRef, ProcName, UseCallType, Args)
         End Function
 
         Public Shared Function Choose(ByVal Index As Double, ByVal ParamArray Choice() As Object) As Object


### PR DESCRIPTION
Fixes compiler magic caused side effect where Versioned.CallByName
ends up in recursion when it's being called.