### PR TITLE
Added support for AssemblyDescription attribute 

### DIFF
--- a/vbnc/vbnc/source/General/TypeCache.Generated.vb
+++ b/vbnc/vbnc/source/General/TypeCache.Generated.vb
@@ -78,6 +78,7 @@ Public Partial Class CecilTypeCache
     Public System_Reflection_AssemblyCompanyAttribute As Mono.Cecil.TypeDefinition
     Public System_Reflection_AssemblyCopyrightAttribute As Mono.Cecil.TypeDefinition
     Public System_Reflection_AssemblyTrademarkAttribute As Mono.Cecil.TypeDefinition
+    Public System_Reflection_AssemblyDescriptionAttribute As Mono.Cecil.TypeDefinition
     Public System_Reflection_AssemblyKeyNameAttribute As Mono.Cecil.TypeDefinition
     Public System_Reflection_AssemblyKeyFileAttribute As Mono.Cecil.TypeDefinition
     Public System_Reflection_AssemblyDelaySignAttribute As Mono.Cecil.TypeDefinition
@@ -351,6 +352,7 @@ Public Partial Class CecilTypeCache
         System_Reflection_AssemblyCompanyAttribute = [GetType](mscorlib, "System.Reflection.AssemblyCompanyAttribute")
         System_Reflection_AssemblyCopyrightAttribute = [GetType](mscorlib, "System.Reflection.AssemblyCopyrightAttribute")
         System_Reflection_AssemblyTrademarkAttribute = [GetType](mscorlib, "System.Reflection.AssemblyTrademarkAttribute")
+        System_Reflection_AssemblyDescriptionAttribute = [GetType](mscorlib, "System.Reflection.AssemblyDescriptionAttribute")
         System_Reflection_AssemblyKeyNameAttribute = [GetType](mscorlib, "System.Reflection.AssemblyKeyNameAttribute")
         System_Reflection_AssemblyKeyFileAttribute = [GetType](mscorlib, "System.Reflection.AssemblyKeyFileAttribute")
         System_Reflection_AssemblyDelaySignAttribute = [GetType](mscorlib, "System.Reflection.AssemblyDelaySignAttribute")

--- a/vbnc/vbnc/source/General/TypeCache.vb
+++ b/vbnc/vbnc/source/General/TypeCache.vb
@@ -487,6 +487,7 @@ Public Partial Class CecilTypeCache
     Public System_Reflection_AssemblyCompanyAttribute As Mono.Cecil.TypeDefinition
     Public System_Reflection_AssemblyCopyrightAttribute As Mono.Cecil.TypeDefinition
     Public System_Reflection_AssemblyTrademarkAttribute As Mono.Cecil.TypeDefinition
+    Public System_Reflection_AssemblyDescriptionAttribute As Mono.Cecil.TypeDefinition
     Public System_Reflection_AssemblyKeyNameAttribute As Mono.Cecil.TypeDefinition
     Public System_Reflection_AssemblyKeyFileAttribute As Mono.Cecil.TypeDefinition
     Public System_Reflection_AssemblyDelaySignAttribute As Mono.Cecil.TypeDefinition
@@ -760,6 +761,7 @@ Public Partial Class CecilTypeCache
         System_Reflection_AssemblyCompanyAttribute = [GetType](mscorlib, "System.Reflection.AssemblyCompanyAttribute")
         System_Reflection_AssemblyCopyrightAttribute = [GetType](mscorlib, "System.Reflection.AssemblyCopyrightAttribute")
         System_Reflection_AssemblyTrademarkAttribute = [GetType](mscorlib, "System.Reflection.AssemblyTrademarkAttribute")
+        System_Reflection_AssemblyDescriptionAttribute = [GetType](mscorlib, "System.Reflection.AssemblyDescriptionAttribute")
         System_Reflection_AssemblyKeyNameAttribute = [GetType](mscorlib, "System.Reflection.AssemblyKeyNameAttribute")
         System_Reflection_AssemblyKeyFileAttribute = [GetType](mscorlib, "System.Reflection.AssemblyKeyFileAttribute")
         System_Reflection_AssemblyDelaySignAttribute = [GetType](mscorlib, "System.Reflection.AssemblyDelaySignAttribute")

--- a/vbnc/vbnc/source/TypeDeclarations/AssemblyDeclaration.vb
+++ b/vbnc/vbnc/source/TypeDeclarations/AssemblyDeclaration.vb
@@ -655,6 +655,7 @@ Public Class AssemblyDeclaration
         Dim company As String = String.Empty
         Dim copyright As String = String.Empty
         Dim trademark As String = String.Empty
+        Dim description As String = String.Empty
 
         Dim att As Mono.Collections.Generic.Collection(Of CustomAttribute)
         Dim custom_attributes As Mono.Collections.Generic.Collection(Of CustomAttribute) = Me.Compiler.AssemblyBuilderCecil.CustomAttributes
@@ -669,6 +670,8 @@ Public Class AssemblyDeclaration
         If att IsNot Nothing AndAlso att.Count > 0 Then copyright = CecilHelper.GetAttributeCtorString(att(0), 0)
         att = CecilHelper.GetCustomAttributes(custom_attributes, Compiler.TypeCache.System_Reflection_AssemblyTrademarkAttribute)
         If att IsNot Nothing AndAlso att.Count > 0 Then trademark = CecilHelper.GetAttributeCtorString(att(0), 0)
+        att = CecilHelper.GetCustomAttributes(custom_attributes, Compiler.TypeCache.System_Reflection_AssemblyDescriptionAttribute)
+        If att IsNot Nothing AndAlso att.Count > 0 Then description = CecilHelper.GetAttributeCtorString(att(0), 0)
 
         'Dim rdt As New Mono.Cecil.PE.ResourceDirectoryTable()
         'Dim r1 As New Mono.Cecil.PE.ResourceDirectoryEntry(16)
@@ -737,6 +740,7 @@ Public Class AssemblyDeclaration
                 If company <> String.Empty Then properties("Company") = company
                 If copyright <> String.Empty Then properties("LegalCopyright") = copyright
                 If trademark <> String.Empty Then properties("LegalTrademark") = trademark
+                If description <> String.Empty Then properties("Comments") = description
 
                 'VS_VERSIONINFO
                 w.Write(CShort(0))


### PR DESCRIPTION
Assemblies built with Mono vbnc are missing the `Comments` element in their FILE_VERSION struct.
.NET Framework VB compiler (and both .NET Framework and Mono C# compilers) fill this element with the value of assembly `<AssemblyDescription>` attribute.

To reproduce it:
1) build this source: `vbnc /target:library /out:test.dll test.vb`
```
' === test.vb ===
Imports System
Imports System.Reflection
Imports System.Runtime.InteropServices

<Assembly: AssemblyTitle("Test")>
<Assembly: AssemblyDescription("Expected description text")>
<Assembly: AssemblyCompany("Assembly company")>
<Assembly: AssemblyProduct("Test")>
<Assembly: AssemblyCopyright("Copyright 2019")>
<Assembly: AssemblyTrademark("")>
<Assembly: ComVisible(False)>
<Assembly: AssemblyVersion("1.2.3.4")>
<Assembly: AssemblyFileVersion("1.2.3.4")>
<Assembly: AssemblyInformationalVersion("1.2.3.4")>
```
2) open test.dll in a resource viewer, like VisualStudio
3) `Expected description text` won't appear anywhere
4) build with the patched vbnc and reopen the new binary; `Expected description text` now appears in "Comments" file version section