### PR TITLE
Implement some events on WindowsFormsApplicationBase

### DIFF
--- a/vbruntime/Microsoft.VisualBasic/Microsoft.VisualBasic.ApplicationServices/WindowsFormsApplicationBase.vb
+++ b/vbruntime/Microsoft.VisualBasic/Microsoft.VisualBasic.ApplicationServices/WindowsFormsApplicationBase.vb
@@ -170,7 +170,6 @@ Namespace Microsoft.VisualBasic.ApplicationServices
 
         <EditorBrowsable(EditorBrowsableState.Advanced)> _
         Protected Overridable Sub OnCreateMainForm()
-            Throw New NotImplementedException
         End Sub
 
         <EditorBrowsable(EditorBrowsableState.Advanced)> _

--- a/vbruntime/Microsoft.VisualBasic/Microsoft.VisualBasic.ApplicationServices/WindowsFormsApplicationBase.vb
+++ b/vbruntime/Microsoft.VisualBasic/Microsoft.VisualBasic.ApplicationServices/WindowsFormsApplicationBase.vb
@@ -91,6 +91,8 @@ Namespace Microsoft.VisualBasic.ApplicationServices
             OnRun()
             'Throw New Exception("Visual Basic 2005 applications are not currently supported (try disabling 'Enable Application Framework')")
             'Application.Run()
+
+            OnShutdown()
 #Else
                         Throw New NotImplementedException
 #End If
@@ -211,7 +213,7 @@ Namespace Microsoft.VisualBasic.ApplicationServices
 
         <EditorBrowsable(EditorBrowsableState.Advanced)> _
         Protected Overridable Sub OnShutdown()
-            Throw New NotImplementedException
+            RaiseEvent Shutdown(new EventArgs())
         End Sub
 
         <EditorBrowsable(EditorBrowsableState.Advanced)> _

--- a/vbruntime/Microsoft.VisualBasic/Microsoft.VisualBasic.ApplicationServices/WindowsFormsApplicationBase.vb
+++ b/vbruntime/Microsoft.VisualBasic/Microsoft.VisualBasic.ApplicationServices/WindowsFormsApplicationBase.vb
@@ -74,6 +74,12 @@ Namespace Microsoft.VisualBasic.ApplicationServices
 
         Public Sub Run(ByVal commandLine() As String)
 #If TARGET_JVM = False Then 'Not Supported by Grasshopper
+            Dim args As ReadOnlyCollection(Of String)
+
+            args = new ReadOnlyCollection(Of String)(commandLine)
+
+            OnInitialize(args)
+
             OnRun()
             'Throw New Exception("Visual Basic 2005 applications are not currently supported (try disabling 'Enable Application Framework')")
             'Application.Run()
@@ -179,7 +185,7 @@ Namespace Microsoft.VisualBasic.ApplicationServices
 
         <EditorBrowsable(EditorBrowsableState.Advanced), STAThread()> _
         Protected Overridable Function OnInitialize(ByVal commandLineArgs As ReadOnlyCollection(Of String)) As Boolean
-            Throw New NotImplementedException
+            'FIXME: call OnCreateSplashScreen
         End Function
 
         <EditorBrowsable(EditorBrowsableState.Advanced)> _

--- a/vbruntime/Microsoft.VisualBasic/Microsoft.VisualBasic.ApplicationServices/WindowsFormsApplicationBase.vb
+++ b/vbruntime/Microsoft.VisualBasic/Microsoft.VisualBasic.ApplicationServices/WindowsFormsApplicationBase.vb
@@ -80,6 +80,14 @@ Namespace Microsoft.VisualBasic.ApplicationServices
 
             OnInitialize(args)
 
+            Dim startup as StartupEventArgs
+
+            startup = New StartupEventArgs(args)
+
+            If Not OnStartup(startup) Then
+                Exit Sub
+            End If
+
             OnRun()
             'Throw New Exception("Visual Basic 2005 applications are not currently supported (try disabling 'Enable Application Framework')")
             'Application.Run()
@@ -208,7 +216,8 @@ Namespace Microsoft.VisualBasic.ApplicationServices
 
         <EditorBrowsable(EditorBrowsableState.Advanced)> _
         Protected Overridable Function OnStartup(ByVal eventArgs As StartupEventArgs) As Boolean
-            Throw New NotImplementedException
+            RaiseEvent Startup(eventArgs)
+            OnStartup = Not eventArgs.Cancel
         End Function
 
         <EditorBrowsable(EditorBrowsableState.Advanced)> _


### PR DESCRIPTION
This adds support for some of the startup and shutdown related events on WindowsFormsApplicationBase. I've often seen VB.NET applications rely on Startup or Initialize being called and fail to start correctly.

Since WindowsFormsApplicationBase can only be used once per process, I don't know how to make a proper unit test for this. I used a test program with WriteLine statements when events/methods are called/exited and compared the output to .NET on Windows.